### PR TITLE
fix rabbit disappearing in upper left corner

### DIFF
--- a/main.c
+++ b/main.c
@@ -2096,6 +2096,8 @@ void steer_players(void)
 
 				s1 = (player[c1].x >> 16);
 				s2 = (player[c1].y >> 16);
+				if (s2 < 0)
+					s2 = 0;
 				if (GET_BAN_MAP_XY((s1 + 8), (s2 + 15)) == BAN_SPRING || ((GET_BAN_MAP_XY(s1, (s2 + 15)) == BAN_SPRING && GET_BAN_MAP_XY((s1 + 15), (s2 + 15)) != BAN_SOLID) || (GET_BAN_MAP_XY(s1, (s2 + 15)) != BAN_SOLID && GET_BAN_MAP_XY((s1 + 15), (s2 + 15)) == BAN_SPRING))) {
 					player[c1].y = ((player[c1].y >> 16) & 0xfff0) << 16;
 					player[c1].y_add = -400000L;


### PR DESCRIPTION
aka "undesired springs added above the screen"

If the bunny jumps out of the screen, its
y-coordinate becomes negative. Thus, the array that is checked for the
position of the objects on the map overflows and returns some bogus,
e.g. that there are springs whereas there aren't. This patch
checks for the y-coordinate and caps it at zero.

c.f. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=370650
